### PR TITLE
Update social example of uacUpdate to include wave metadata

### DIFF
--- a/event_dictionary/0.4.0/examples/social/uacUpdate.example.json
+++ b/event_dictionary/0.4.0/examples/social/uacUpdate.example.json
@@ -17,7 +17,7 @@
       "qid": "id amet aliqua",
       "receiptReceived": true,
       "metadata": {
-        "occaecat049": false
+        "wave": 3
       },
       "eqLaunched": false
     }

--- a/polish_example_json.py
+++ b/polish_example_json.py
@@ -48,7 +48,8 @@ with open('event.example.json', 'r') as event_file:
             sample_key: f"dummy_{''.join(random.choices(string.ascii_lowercase + string.digits, k=10))}"
             for sample_key in sensitive_column_names}
 
-        fake_sample_sensitive_redacted = {sample_key: "REDACTED" for sample_key in sensitive_column_names}
+        fake_sample_sensitive_redacted = {
+            sample_key: "REDACTED" for sample_key in sensitive_column_names}
 
         for event_item in events:
             with open(f'{event_item["event"]}.example.json', 'r') as specific_event_file:
@@ -73,7 +74,12 @@ with open('event.example.json', 'r') as event_file:
                         event["payload"]["surveyUpdate"]["name"] = survey_type["type"].upper()
 
                     event["payload"]["surveyUpdate"]["sampleDefinition"] = shape_file
-                    event["payload"]["surveyUpdate"]["sampleDefinitionUrl"] = f'{URL_PREFIX}{survey_type["shape"]}'
+                    event["payload"]["surveyUpdate"][
+                        "sampleDefinitionUrl"] = f'{URL_PREFIX}{survey_type["shape"]}'
+
+                if event_item["event"] == 'uacUpdate':
+                    if survey_type["type"] == 'social':
+                        event["payload"]["uacUpdate"]["metadata"] = {"wave": 3}
 
                 if event_item["event"] == 'collectionExerciseUpdate':
                     if survey_type["type"] == 'social':


### PR DESCRIPTION
Tweak to social version of `uacUpdate` to show what metadata would look like.

Usually this would require a version bump, but because it's just an example rather than a change to the schema, we are bending the rules.