### PR TITLE
Added dataErase on refusal event and new refusal type

### DIFF
--- a/event_dictionary/0.6.0-DRAFT/caseUpdate.schema.json
+++ b/event_dictionary/0.6.0-DRAFT/caseUpdate.schema.json
@@ -39,7 +39,8 @@
             null,
             "HARD_REFUSAL",
             "EXTRAORDINARY_REFUSAL",
-            "SOFT_REFUSAL"
+            "SOFT_REFUSAL",
+            "WITHDRAWAL_REFUSAL"
           ]
         },
         "sample": {

--- a/event_dictionary/0.6.0-DRAFT/dictionary.md
+++ b/event_dictionary/0.6.0-DRAFT/dictionary.md
@@ -61,6 +61,7 @@
     - [2.9.1. Property `Event > payload > oneOf > Refusal > refusal`](#payload_oneOf_i8_refusal)
       - [2.9.1.1. Property `Event > payload > oneOf > Refusal > refusal > caseId`](#payload_oneOf_i8_refusal_caseId)
       - [2.9.1.2. Property `Event > payload > oneOf > Refusal > refusal > type`](#payload_oneOf_i8_refusal_type)
+      - [2.9.1.3. Property `Event > payload > oneOf > Refusal > refusal > eraseData`](#payload_oneOf_i8_refusal_eraseData)
   - [2.10. Property `Event > payload > oneOf > surveyUpdate.schema.json`](#payload_oneOf_i9)
     - [2.10.1. Property `Event > payload > oneOf > Survey Update > surveyUpdate`](#payload_oneOf_i9_surveyUpdate)
       - [2.10.1.1. Property `Event > payload > oneOf > Survey Update > surveyUpdate > surveyId`](#payload_oneOf_i9_surveyUpdate_surveyId)
@@ -1062,11 +1063,12 @@ Must be one of:
 | **Additional properties** | [[Not allowed]](# "Additional Properties not allowed.") |
 |                           |                                                         |
 
-| Property                                      | Pattern | Type             | Deprecated | Definition | Title/Description                         |
-| --------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------------------------- |
-| + [caseId](#payload_oneOf_i8_refusal_caseId ) | No      | uuid             | No         | -          | The ID of the case that is being refused. |
-| + [type](#payload_oneOf_i8_refusal_type )     | No      | enum (of string) | No         | -          | The type of the refusal.                  |
-|                                               |         |                  |            |            |                                           |
+| Property                                            | Pattern | Type             | Deprecated | Definition | Title/Description                         |
+| --------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------------------------- |
+| + [caseId](#payload_oneOf_i8_refusal_caseId )       | No      | uuid             | No         | -          | The ID of the case that is being refused. |
+| + [type](#payload_oneOf_i8_refusal_type )           | No      | enum (of string) | No         | -          | The type of the refusal.                  |
+| - [eraseData](#payload_oneOf_i8_refusal_eraseData ) | No      | boolean          | No         | -          | Data erasure request has been received    |
+|                                                     |         |                  |            |            |                                           |
 
 ##### <a name="payload_oneOf_i8_refusal_caseId"></a>2.9.1.1. Property `Event > payload > oneOf > Refusal > refusal > caseId`
 
@@ -1096,6 +1098,26 @@ Must be one of:
 * "HARD_REFUSAL"
 * "EXTRAORDINARY_REFUSAL"
 * "SOFT_REFUSAL"
+* "WITHDRAWAL_REFUSAL"
+
+##### <a name="payload_oneOf_i8_refusal_eraseData"></a>2.9.1.3. Property `Event > payload > oneOf > Refusal > refusal > eraseData`
+
+| Type                      | `boolean`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+**Description:** Data erasure request has been received
+
+**Examples:** 
+
+```json
+true
+```
+
+```json
+false
+```
 
 ### <a name="payload_oneOf_i9"></a>2.10. Property `Event > payload > oneOf > surveyUpdate.schema.json`
 
@@ -1954,4 +1976,4 @@ false
 ```
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2022-01-20 at 08:29:38 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2022-02-16 at 10:50:48 +0000

--- a/event_dictionary/0.6.0-DRAFT/dictionary.md
+++ b/event_dictionary/0.6.0-DRAFT/dictionary.md
@@ -1063,12 +1063,12 @@ Must be one of:
 | **Additional properties** | [[Not allowed]](# "Additional Properties not allowed.") |
 |                           |                                                         |
 
-| Property                                            | Pattern | Type             | Deprecated | Definition | Title/Description                         |
-| --------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------------------------- |
-| + [caseId](#payload_oneOf_i8_refusal_caseId )       | No      | uuid             | No         | -          | The ID of the case that is being refused. |
-| + [type](#payload_oneOf_i8_refusal_type )           | No      | enum (of string) | No         | -          | The type of the refusal.                  |
-| - [eraseData](#payload_oneOf_i8_refusal_eraseData ) | No      | boolean          | No         | -          | Data erasure request has been received    |
-|                                                     |         |                  |            |            |                                           |
+| Property                                            | Pattern | Type             | Deprecated | Definition | Title/Description                                         |
+| --------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | --------------------------------------------------------- |
+| + [caseId](#payload_oneOf_i8_refusal_caseId )       | No      | uuid             | No         | -          | The ID of the case that is being refused.                 |
+| + [type](#payload_oneOf_i8_refusal_type )           | No      | enum (of string) | No         | -          | The type of the refusal.                                  |
+| - [eraseData](#payload_oneOf_i8_refusal_eraseData ) | No      | boolean          | No         | -          | Optional flag for data erasure request, defaults to false |
+|                                                     |         |                  |            |            |                                                           |
 
 ##### <a name="payload_oneOf_i8_refusal_caseId"></a>2.9.1.1. Property `Event > payload > oneOf > Refusal > refusal > caseId`
 
@@ -1107,7 +1107,7 @@ Must be one of:
 | **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
 |                           |                                                                           |
 
-**Description:** Data erasure request has been received
+**Description:** Optional flag for data erasure request, defaults to false
 
 **Examples:** 
 
@@ -1976,4 +1976,4 @@ false
 ```
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2022-02-16 at 10:50:48 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2022-02-16 at 14:14:26 +0000

--- a/event_dictionary/0.6.0-DRAFT/dictionary.md
+++ b/event_dictionary/0.6.0-DRAFT/dictionary.md
@@ -437,6 +437,7 @@ Must be one of:
 * "HARD_REFUSAL"
 * "EXTRAORDINARY_REFUSAL"
 * "SOFT_REFUSAL"
+* "WITHDRAWAL_REFUSAL"
 
 ##### <a name="payload_oneOf_i0_caseUpdate_sample"></a>2.1.1.7. Property `Event > payload > oneOf > Case Update > caseUpdate > sample`
 
@@ -1976,4 +1977,4 @@ false
 ```
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2022-02-16 at 14:14:26 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2022-02-17 at 12:03:15 +0000

--- a/event_dictionary/0.6.0-DRAFT/examples/business/refusal.example.json
+++ b/event_dictionary/0.6.0-DRAFT/examples/business/refusal.example.json
@@ -12,7 +12,8 @@
   "payload": {
     "refusal": {
       "caseId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "type": "EXTRAORDINARY_REFUSAL"
+      "type": "EXTRAORDINARY_REFUSAL",
+      "eraseData": false
     }
   }
 }

--- a/event_dictionary/0.6.0-DRAFT/examples/sis/refusal.example.json
+++ b/event_dictionary/0.6.0-DRAFT/examples/sis/refusal.example.json
@@ -12,7 +12,8 @@
   "payload": {
     "refusal": {
       "caseId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "type": "EXTRAORDINARY_REFUSAL"
+      "type": "EXTRAORDINARY_REFUSAL",
+      "eraseData": false
     }
   }
 }

--- a/event_dictionary/0.6.0-DRAFT/examples/social/refusal.example.json
+++ b/event_dictionary/0.6.0-DRAFT/examples/social/refusal.example.json
@@ -12,7 +12,8 @@
   "payload": {
     "refusal": {
       "caseId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "type": "EXTRAORDINARY_REFUSAL"
+      "type": "EXTRAORDINARY_REFUSAL",
+      "eraseData": false
     }
   }
 }

--- a/event_dictionary/0.6.0-DRAFT/refusal.schema.json
+++ b/event_dictionary/0.6.0-DRAFT/refusal.schema.json
@@ -23,7 +23,7 @@
           ]
         },
         "eraseData": {
-          "description": "Data erasure request has been received",
+          "description": "Optional flag for data erasure request, defaults to false",
           "type": "boolean",
           "examples": [true, false]
         }

--- a/event_dictionary/0.6.0-DRAFT/refusal.schema.json
+++ b/event_dictionary/0.6.0-DRAFT/refusal.schema.json
@@ -15,7 +15,17 @@
         "type": {
           "type": "string",
           "description": "The type of the refusal.",
-          "enum": ["HARD_REFUSAL", "EXTRAORDINARY_REFUSAL", "SOFT_REFUSAL"]
+          "enum": [
+            "HARD_REFUSAL",
+            "EXTRAORDINARY_REFUSAL",
+            "SOFT_REFUSAL",
+            "WITHDRAWAL_REFUSAL"
+          ]
+        },
+        "eraseData": {
+          "description": "Data erasure request has been received",
+          "type": "boolean",
+          "examples": [true, false]
         }
       },
       "required": ["caseId", "type"],


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During a survey someone might want to withdraw from a survey after previously agreeing to take part. This PR adds in a new withdrawal type to the refusal event. If someone asks for us to remove all their sensitive data, we can now do that with the eraseData field on the event as well  

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Withdrawal_refusal type on refusal event
- Can request for your sensitive data to be removed 
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/q8cx1tZn/)

